### PR TITLE
Dev

### DIFF
--- a/FFmpegPlayer.h
+++ b/FFmpegPlayer.h
@@ -26,10 +26,8 @@ extern "C" {
 class FFmpegPlayer
 {
 public:
-    explicit FFmpegPlayer();
+    FFmpegPlayer();
     ~FFmpegPlayer();
-public:
-
 public:
 
     /**
@@ -46,7 +44,6 @@ public:
      * @return 0成功
      */
     int start_preview(const std::string &media_url);
-    int resize_view(int width, int height);
     /**
      * @brief stop_preview 异步的停止预览，清理ffmpeg资源，异步停止播放线程，成功停止会回调on_stop_preview.也会停止其他功能
      * @return 0成功
@@ -159,6 +156,7 @@ private:
     int height = 0;
     int m_videoStream = -1;
     int m_audioStream = -1;
+    std::unique_ptr<std::future<void>> m_playerFutureObserver = nullptr;
 };
 
 #endif // FFMPEGPLAYER_H

--- a/FFmpegPlayer.h
+++ b/FFmpegPlayer.h
@@ -46,6 +46,7 @@ public:
      * @return 0成功
      */
     int start_preview(const std::string &media_url);
+    int resize_view(int width, int height);
     /**
      * @brief stop_preview 异步的停止预览，清理ffmpeg资源，异步停止播放线程，成功停止会回调on_stop_preview.也会停止其他功能
      * @return 0成功
@@ -86,7 +87,7 @@ protected:
     virtual void on_player_error(int errnum);
 
     //播放线程启动成功回调
-    virtual void on_preview_start(const std::string& media_url);
+    virtual void on_preview_start(const std::string& media_url, const int width, const int height);
     //播放线程关闭回调，不管是否报错，播放线程结束就回调,可以在里面重启播放器
     virtual void on_preview_stop(const std::string& media_url);
 
@@ -154,6 +155,8 @@ private:
     PlayerStatus player_status = PLAYER_STATUS_IDLE;
     RecorderStatus recorder_status = RECORDER_STATUS_IDLE;
 
+    int width = 0;
+    int height = 0;
     int m_videoStream = -1;
     int m_audioStream = -1;
 };

--- a/QGLPlayerWidget.cpp
+++ b/QGLPlayerWidget.cpp
@@ -1,9 +1,13 @@
 #include <QGLPlayerWidget.h>
 #include <QDateTime> // for log
+#include <QStyle>
 
 QGLPlayerWidget::QGLPlayerWidget(QWidget *parent)
     : QOpenGLWidget(parent),
       m_audioPlayer(new QAudioPlayer(8192 * 16))
+{
+}
+QGLPlayerWidget::~QGLPlayerWidget()
 {
 }
 void QGLPlayerWidget::start_preview(const std::string &media_url)
@@ -27,6 +31,60 @@ void QGLPlayerWidget::stop_local_record()
 void QGLPlayerWidget::initializeGL()
 {
     initializeOpenGLFunctions();
+    // 创建并编译顶点着色器和片段着色器
+    const char *vertexShaderSource = "#version 330 core\n"
+                                     "layout(location = 0) in vec2 position;\n"
+                                     "out vec2 texCoord;\n"
+                                     "void main()\n"
+                                     "{\n"
+                                     "    gl_Position = vec4(position, 0.0, 1.0);\n"
+                                     "    texCoord = vec2((position.x + 1.0) / 2.0, 1.0 - (position.y + 1.0) / 2.0);\n"
+                                     "}\n";
+
+    const char *fragmentShaderSource = "#version 330 core\n"
+                                       "in vec2 texCoord;\n"
+                                       "out vec4 FragColor;\n"
+                                       "uniform sampler2D textureSampler;\n"
+                                       "void main()\n"
+                                       "{\n"
+                                       "    FragColor = texture(textureSampler, texCoord);\n"
+                                       "}\n";
+
+    GLuint vertexShader, fragmentShader;
+    vertexShader = glCreateShader(GL_VERTEX_SHADER);
+    glShaderSource(vertexShader, 1, &vertexShaderSource, NULL);
+    glCompileShader(vertexShader);
+
+    fragmentShader = glCreateShader(GL_FRAGMENT_SHADER);
+    glShaderSource(fragmentShader, 1, &fragmentShaderSource, NULL);
+    glCompileShader(fragmentShader);
+
+    // 创建着色器程序
+    shaderProgram = glCreateProgram();
+    glAttachShader(shaderProgram, vertexShader);
+    glAttachShader(shaderProgram, fragmentShader);
+    glLinkProgram(shaderProgram);
+
+    // 删除着色器对象，因为它们已经链接到着色器程序中
+    glDeleteShader(vertexShader);
+    glDeleteShader(fragmentShader);
+
+    // 创建矩形的顶点数据
+    float vertices[] = {
+        -1.0f, -1.0f,
+        1.0f, -1.0f,
+        1.0f,  1.0f,
+        -1.0f,  1.0f
+    };
+
+    // 创建顶点缓冲对象并传递数据
+    glGenBuffers(1, &vbo);
+    glBindBuffer(GL_ARRAY_BUFFER, vbo);
+    glBufferData(GL_ARRAY_BUFFER, sizeof(vertices), vertices, GL_STATIC_DRAW);
+
+    // 设置顶点属性指针
+    glEnableVertexAttribArray(0);
+    glVertexAttribPointer(0, 2, GL_FLOAT, GL_FALSE, 0, 0);
 
     // 设置OpenGL状态，例如清除颜色和启用纹理2D
     glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
@@ -34,54 +92,71 @@ void QGLPlayerWidget::initializeGL()
 }
 void QGLPlayerWidget::resizeGL(int w, int h)
 {
+    qDebug() << __FUNCTION__ << "resize->" << w << "x" << h;
     glViewport(0, 0, w, h);
 }
 void QGLPlayerWidget::paintGL()
 {
-//    qDebug() << __FUNCTION__ << QDateTime::currentDateTime().toMSecsSinceEpoch();
+    qDebug() << __FUNCTION__ << QDateTime::currentDateTime().toMSecsSinceEpoch();
     if(!FFmpegPlayer::frame_consumed.load(std::memory_order_acquire))
     {
-        if(init_texture_flag.load(std::memory_order_acquire))
-        {
-            // 创建纹理对象
-            glGenTextures(1, &textureID);
-            glBindTexture(GL_TEXTURE_2D, textureID);
-            glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, m_frame_cache->m_cache->width, m_frame_cache->m_cache->height, 0, GL_RGBA, GL_UNSIGNED_BYTE, nullptr);
-            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-            init_texture_flag.store(false, std::memory_order_release);
-        }
         glClear(GL_COLOR_BUFFER_BIT);
         glBindTexture(GL_TEXTURE_2D, textureID);
         glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0,
                         m_frame_cache->m_cache->width,
                         m_frame_cache->m_cache->height, GL_RGBA, GL_UNSIGNED_BYTE, m_frame_cache->m_cache->data[0]);
+//        // 绘制纹理
+//        glBegin(GL_QUADS);
+//        glTexCoord2f(0.0, 1.0); glVertex2f(-1.0, -1.0);  // 左下角
+//        glTexCoord2f(1.0, 1.0); glVertex2f(1.0, -1.0);   // 右下角
+//        glTexCoord2f(1.0, 0.0); glVertex2f(1.0, 1.0);    // 右上角
+//        glTexCoord2f(0.0, 0.0); glVertex2f(-1.0, 1.0);   // 左上角
+//        glEnd();
 
-        // 绘制纹理
-        glBegin(GL_QUADS);
-        glTexCoord2f(0.0, 1.0); glVertex2f(-1.0, -1.0);  // 左下角
-        glTexCoord2f(1.0, 1.0); glVertex2f(1.0, -1.0);   // 右下角
-        glTexCoord2f(1.0, 0.0); glVertex2f(1.0, 1.0);    // 右上角
-        glTexCoord2f(0.0, 0.0); glVertex2f(-1.0, 1.0);   // 左上角
-        glEnd();
+        // 使用现代OpenGL着色器
+        glUseProgram(shaderProgram);
+
+        // 绑定顶点缓冲对象
+        glBindBuffer(GL_ARRAY_BUFFER, vbo);
+
+        // 启用顶点属性
+        glEnableVertexAttribArray(0);
+        glVertexAttribPointer(0, 2, GL_FLOAT, GL_FALSE, 0, 0);
+
+        // 绘制矩形
+        glDrawArrays(GL_TRIANGLE_FAN, 0, 4);
+
+        // 禁用顶点属性
+        glDisableVertexAttribArray(0);
+
+        glUseProgram(0);
+
         FFmpegPlayer::frame_consumed.store(true, std::memory_order_release);
     }
 }
 
 void QGLPlayerWidget::on_new_frame_avaliable()
 {
-    this->update();
+    QMetaObject::invokeMethod(this, [&](){
+        this->update();
+    }, Qt::QueuedConnection);
 }
-void QGLPlayerWidget::on_preview_start(const std::string& media_url)
+void QGLPlayerWidget::on_preview_start(const std::string& media_url, const int width, const int height)
 {
-//    qDebug() << __FUNCTION__ ;
-    init_texture_flag.store(true, std::memory_order_release);
+    qDebug() << __FUNCTION__  << width << height;
+    QMetaObject::invokeMethod(this, [&](){
+        makeCurrent();
+        glGenTextures(1, &textureID);
+        glBindTexture(GL_TEXTURE_2D, textureID);
+        glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, nullptr);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+    }, Qt::QueuedConnection);
 }
 
 void QGLPlayerWidget::on_preview_stop(const std::string& media_url)
 {
-//    qDebug() << __FUNCTION__ ;
-    init_texture_flag.store(false, std::memory_order_release);
+    qDebug() << __FUNCTION__ ;
 }
 
 void QGLPlayerWidget::on_new_audio_frame_avaliable(std::shared_ptr<FrameCache> m_frame_cache)

--- a/QGLPlayerWidget.cpp
+++ b/QGLPlayerWidget.cpp
@@ -90,10 +90,8 @@ void QGLPlayerWidget::initializeGL()
     glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
     glEnable(GL_TEXTURE_2D);
 }
-void QGLPlayerWidget::resizeGL(int w, int h)
+void QGLPlayerWidget::setup_viewport(int w, int h)
 {
-    qDebug() << __FUNCTION__ << "resize->" << w << "x" << h;
-
     float current_aspectRatio = float(w) / float(h);
     // 计算需要填充黑色背景的区域
     int x, y, newWidth, newHeight;
@@ -115,14 +113,18 @@ void QGLPlayerWidget::resizeGL(int w, int h)
     viewport_h = newHeight;
     viewport_x = x;
     viewport_y = y;
+}
+void QGLPlayerWidget::resizeGL(int w, int h)
+{
+    qDebug() << __FUNCTION__ << "resize->" << w << "x" << h;
+
+    setup_viewport(w, h);
     glViewport(viewport_x, viewport_y, viewport_w, viewport_h);
-
-
 //    glViewport(0, 0, w, h);
 }
 void QGLPlayerWidget::paintGL()
 {
-    qDebug() << __FUNCTION__ << QDateTime::currentDateTime().toMSecsSinceEpoch();
+//    qDebug() << __FUNCTION__ << QDateTime::currentDateTime().toMSecsSinceEpoch();
     if(!FFmpegPlayer::frame_consumed.load(std::memory_order_acquire))
     {
         glViewport(viewport_x, viewport_y, viewport_w, viewport_h);
@@ -170,6 +172,7 @@ void QGLPlayerWidget::on_new_frame_avaliable()
 void QGLPlayerWidget::on_preview_start(const std::string& media_url, const int width, const int height)
 {
     aspectRatio = (float)width / (float)height;
+    setup_viewport(QWidget::width(), QWidget::height());
     qDebug() << __FUNCTION__  << width << height << aspectRatio;
     QMetaObject::invokeMethod(this, [&](){
         makeCurrent();

--- a/QGLPlayerWidget.cpp
+++ b/QGLPlayerWidget.cpp
@@ -88,10 +88,12 @@ void QGLPlayerWidget::initializeGL()
 
     // 设置OpenGL状态，例如清除颜色和启用纹理2D
     glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
-    glEnable(GL_TEXTURE_2D);
+//    glEnable(GL_TEXTURE_2D);
 }
 void QGLPlayerWidget::setup_viewport(int w, int h)
 {
+    if(!w||!h)
+        return;
     float current_aspectRatio = float(w) / float(h);
     // 计算需要填充黑色背景的区域
     int x, y, newWidth, newHeight;
@@ -117,7 +119,6 @@ void QGLPlayerWidget::setup_viewport(int w, int h)
 void QGLPlayerWidget::resizeGL(int w, int h)
 {
     qDebug() << __FUNCTION__ << "resize->" << w << "x" << h;
-
     setup_viewport(w, h);
     glViewport(viewport_x, viewport_y, viewport_w, viewport_h);
 //    glViewport(0, 0, w, h);
@@ -171,9 +172,9 @@ void QGLPlayerWidget::on_new_frame_avaliable()
 }
 void QGLPlayerWidget::on_preview_start(const std::string& media_url, const int width, const int height)
 {
+    qDebug() << __FUNCTION__  << width << height;
     aspectRatio = (float)width / (float)height;
     setup_viewport(QWidget::width(), QWidget::height());
-    qDebug() << __FUNCTION__  << width << height << aspectRatio;
     QMetaObject::invokeMethod(this, [&](){
         makeCurrent();
         glGenTextures(1, &textureID);
@@ -182,12 +183,14 @@ void QGLPlayerWidget::on_preview_start(const std::string& media_url, const int w
         glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
         glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
     }, Qt::QueuedConnection);
+    emit sig_on_preview_start(QString(media_url.c_str()), width, height);
 }
 
 void QGLPlayerWidget::on_preview_stop(const std::string& media_url)
 {
     qDebug() << __FUNCTION__ ;
     aspectRatio = 0;
+    emit sig_on_preview_stop(QString(media_url.c_str()));
 }
 
 void QGLPlayerWidget::on_new_audio_frame_avaliable(std::shared_ptr<FrameCache> m_frame_cache)

--- a/QGLPlayerWidget.h
+++ b/QGLPlayerWidget.h
@@ -27,6 +27,12 @@ class QGLPlayerWidget : public QOpenGLWidget, protected QOpenGLFunctions, protec
 public:
     QGLPlayerWidget(QWidget *parent = nullptr);
     ~QGLPlayerWidget();
+signals:
+    void sig_on_preview_start(const QString &media_url, const int width, const int heigh);
+    void sig_on_preview_stop(const QString &media_url);
+    void sig_on_record_start();
+    void sig_on_record_stop();
+
 public slots:
     void start_preview(const std::string &media_url);
     void stop_preview();

--- a/QGLPlayerWidget.h
+++ b/QGLPlayerWidget.h
@@ -43,6 +43,7 @@ protected:
     void on_new_frame_avaliable() override;
     void on_new_audio_frame_avaliable(std::shared_ptr<FrameCache> m_frame_cache) override;
 private:
+    void setup_viewport(int view_w, int view_h);
     GLuint shaderProgram;  // 着色器程序
     GLuint vbo;  // 顶点缓冲对象
     GLuint textureID;

--- a/QGLPlayerWidget.h
+++ b/QGLPlayerWidget.h
@@ -3,6 +3,7 @@
 
 #include <functional>
 
+#include <QtWidgets>
 #include <QOpenGLWidget>
 #include <QOpenGLFunctions>
 #include <QOpenGLShaderProgram>
@@ -45,8 +46,8 @@ private:
     GLuint shaderProgram;  // 着色器程序
     GLuint vbo;  // 顶点缓冲对象
     GLuint textureID;
-    int width;
-    int height;
+    int viewport_x = 0, viewport_y = 0, viewport_w = 0, viewport_h = 0;
+    float aspectRatio = 0;
     std::unique_ptr<QAudioPlayer> m_audioPlayer;
 };
 

--- a/QGLPlayerWidget.h
+++ b/QGLPlayerWidget.h
@@ -25,7 +25,7 @@ class QGLPlayerWidget : public QOpenGLWidget, protected QOpenGLFunctions, protec
 
 public:
     QGLPlayerWidget(QWidget *parent = nullptr);
-    ~QGLPlayerWidget() = default;
+    ~QGLPlayerWidget();
 public slots:
     void start_preview(const std::string &media_url);
     void stop_preview();
@@ -37,15 +37,16 @@ public slots:
     void paintGL() override;
 
 protected:
-    void on_preview_start(const std::string& media_url) override;
+    void on_preview_start(const std::string& media_url, const int width, const int height) override;
     void on_preview_stop(const std::string& media_url) override;
     void on_new_frame_avaliable() override;
     void on_new_audio_frame_avaliable(std::shared_ptr<FrameCache> m_frame_cache) override;
 private:
+    GLuint shaderProgram;  // 着色器程序
+    GLuint vbo;  // 顶点缓冲对象
     GLuint textureID;
     int width;
     int height;
-    std::atomic_bool init_texture_flag = true;
     std::unique_ptr<QAudioPlayer> m_audioPlayer;
 };
 

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -14,87 +14,75 @@
    <string>MainWindow</string>
   </property>
   <widget class="QWidget" name="centralwidget">
-   <widget class="QTabWidget" name="tab_widget">
-    <property name="geometry">
-     <rect>
-      <x>20</x>
-      <y>40</y>
-      <width>1604</width>
-      <height>926</height>
-     </rect>
-    </property>
-    <property name="currentIndex">
-     <number>1</number>
-    </property>
-    <widget class="QPlayerWidget" name="player_widget">
-     <attribute name="title">
-      <string>player_widget</string>
-     </attribute>
-    </widget>
-    <widget class="QGLPlayerWidget" name="gl_player_widget">
-     <attribute name="title">
-      <string>gl_player_widget</string>
-     </attribute>
-    </widget>
-   </widget>
-   <widget class="QWidget" name="layoutWidget">
-    <property name="geometry">
-     <rect>
-      <x>20</x>
-      <y>10</y>
-      <width>931</width>
-      <height>26</height>
-     </rect>
-    </property>
-    <layout class="QHBoxLayout" name="horizontalLayout_3">
-     <item>
-      <layout class="QHBoxLayout" name="horizontalLayout_2">
-       <item>
-        <widget class="QLabel" name="url_label">
-         <property name="text">
-          <string>url:</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QLineEdit" name="url_line_edit"/>
-       </item>
-      </layout>
-     </item>
-     <item>
-      <layout class="QHBoxLayout" name="horizontalLayout">
-       <item>
-        <widget class="QPushButton" name="button_start_preview">
-         <property name="text">
-          <string>start_preview</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QPushButton" name="button_stop_preview">
-         <property name="text">
-          <string>stop_preview</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QPushButton" name="button_start_record">
-         <property name="text">
-          <string>start_record</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QPushButton" name="button_stop_record">
-         <property name="text">
-          <string>stop_record</string>
-         </property>
-        </widget>
-       </item>
-      </layout>
-     </item>
-    </layout>
-   </widget>
+   <layout class="QGridLayout" name="gridLayout">
+    <item row="0" column="0">
+     <layout class="QHBoxLayout" name="horizontalLayout_3">
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_2">
+        <item>
+         <widget class="QLabel" name="url_label">
+          <property name="text">
+           <string>url:</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLineEdit" name="url_line_edit"/>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout">
+        <item>
+         <widget class="QPushButton" name="button_start_preview">
+          <property name="text">
+           <string>start_preview</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="button_stop_preview">
+          <property name="text">
+           <string>stop_preview</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="button_start_record">
+          <property name="text">
+           <string>start_record</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="button_stop_record">
+          <property name="text">
+           <string>stop_record</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </item>
+    <item row="1" column="0">
+     <widget class="QTabWidget" name="tab_widget">
+      <property name="currentIndex">
+       <number>0</number>
+      </property>
+      <widget class="QPlayerWidget" name="player_widget">
+       <attribute name="title">
+        <string>player_widget</string>
+       </attribute>
+      </widget>
+      <widget class="QGLPlayerWidget" name="gl_player_widget">
+       <attribute name="title">
+        <string>gl_player_widget</string>
+       </attribute>
+      </widget>
+     </widget>
+    </item>
+   </layout>
   </widget>
   <widget class="QMenuBar" name="menubar">
    <property name="geometry">
@@ -110,15 +98,15 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>QPlayerWidget</class>
-   <extends>QWidget</extends>
-   <header location="global">QPlayerWidget.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
    <class>QGLPlayerWidget</class>
    <extends>QWidget</extends>
    <header location="global">QGLPlayerWidget.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QPlayerWidget</class>
+   <extends>QWidget</extends>
+   <header location="global">QPlayerWidget.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -15,6 +15,29 @@
   </property>
   <widget class="QWidget" name="centralwidget">
    <layout class="QGridLayout" name="gridLayout">
+    <item row="1" column="0">
+     <widget class="QTabWidget" name="tab_widget">
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="currentIndex">
+       <number>1</number>
+      </property>
+      <widget class="QPlayerWidget" name="player_widget">
+       <attribute name="title">
+        <string>player_widget</string>
+       </attribute>
+      </widget>
+      <widget class="QGLPlayerWidget" name="gl_player_widget">
+       <attribute name="title">
+        <string>gl_player_widget</string>
+       </attribute>
+      </widget>
+     </widget>
+    </item>
     <item row="0" column="0">
      <layout class="QHBoxLayout" name="horizontalLayout_3">
       <item>
@@ -64,23 +87,6 @@
        </layout>
       </item>
      </layout>
-    </item>
-    <item row="1" column="0">
-     <widget class="QTabWidget" name="tab_widget">
-      <property name="currentIndex">
-       <number>0</number>
-      </property>
-      <widget class="QPlayerWidget" name="player_widget">
-       <attribute name="title">
-        <string>player_widget</string>
-       </attribute>
-      </widget>
-      <widget class="QGLPlayerWidget" name="gl_player_widget">
-       <attribute name="title">
-        <string>gl_player_widget</string>
-       </attribute>
-      </widget>
-     </widget>
     </item>
    </layout>
   </widget>


### PR DESCRIPTION
修复直接关闭时析构顺序错误的问题，现在播放时可以直接关闭窗口。
现在opengl使用自己定义的vbo渲染
openglwidget现在会按码流的宽高比显示，不做拉伸，如果要拉伸，只需要去掉缩放计算和viewport变换
